### PR TITLE
Add undo card message

### DIFF
--- a/src/rooms/schema/CrewTypes.ts
+++ b/src/rooms/schema/CrewTypes.ts
@@ -69,6 +69,8 @@ export class Player extends Schema {
 export class Trick extends Schema {
   @type([Card]) playedCards = new ArraySchema<Card>();
   @type(["string"]) playerOrder = new ArraySchema<string>();
+  // Track whether each played card was originally communicated
+  @type(["boolean"]) communicationFlags = new ArraySchema<boolean>();
   @type("string") trickWinner: string;
   @type("boolean") trickCompleted: boolean;
 }


### PR DESCRIPTION
## Summary
- add `communicationFlags` to `Trick` schema to track played communication cards
- push communication info when cards are played
- add `undo_card` room message for players to revert their last play

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854de2f0c90832cafae9abf9eafe53e