### PR TITLE
Implement communication intention controls

### DIFF
--- a/src/rooms/schema/CrewTypes.ts
+++ b/src/rooms/schema/CrewTypes.ts
@@ -60,6 +60,7 @@ export class Player extends Schema {
   @type("boolean") hasCommunicated: boolean = false;
   @type(Card) communicationCard: Card;
   @type("string") communicationRank: CommunicationRank;
+  @type("boolean") intendsToCommunicate: boolean = false;
 
   @type("boolean") isHost: boolean = false;
   @type("boolean") isConnected: boolean = true;


### PR DESCRIPTION
## Summary
- add `intendsToCommunicate` flag to player schema
- block card plays when any player intends to communicate
- handle messages `intend_communication` and `cancel_intention`
- clear communication intent on leave, communication, and reset

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854eaf37194832c9d840720f23e2df7