### PR TITLE
Add available rooms endpoint and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,33 @@ npm start
         - `npm run loadtest`: runs the [`@colyseus/loadtest`](https://github.com/colyseus/colyseus-loadtest/) tool for testing the connection, using the `loadtest/example.ts` script.
 - `tsconfig.json`: TypeScript configuration file
 
+## HTTP API
+
+### `GET /available_rooms`
+
+Returns a list of active `crew` rooms that are open for players to join. Each
+entry includes the room identifier and current occupancy information.
+
+Example response:
+
+```json
+[
+  {
+    "roomId": "abcd",
+    "clients": 2,
+    "maxClients": 5,
+    "metadata": {}
+  }
+]
+```
+
+The `roomId` from the response can be passed to the Colyseus client when joining
+a room:
+
+```ts
+client.joinById(roomId, { displayName: "My Name" });
+```
+
 
 ## License
 

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -1,6 +1,7 @@
 import config from "@colyseus/tools";
 import { monitor } from "@colyseus/monitor";
 import { playground } from "@colyseus/playground";
+import { matchMaker } from "colyseus";
 
 /**
  * Import your Room files
@@ -24,6 +25,17 @@ export default config({
          */
         app.get("/hello_world", (req, res) => {
             res.send("It's time to kick ass and chew bubblegum!");
+        });
+
+        // Endpoint to list available rooms
+        app.get("/available_rooms", async (_req, res) => {
+            try {
+                const rooms = await matchMaker.query({ name: "crew" });
+                res.json(rooms);
+            } catch (err) {
+                console.error("failed to get available rooms", err);
+                res.status(500).json({ error: "failed_to_fetch_rooms" });
+            }
         });
 
         /**


### PR DESCRIPTION
## Summary
- expose `/available_rooms` REST endpoint using Colyseus matchMaker
- document how to query available rooms and join them

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f43435db0832c8c9e76178d86aa4d