### PR TITLE
Add random highscore API and robust DB connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 SHARED_SECRET=secret123
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/crew

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -7,6 +7,7 @@ import { matchMaker } from "colyseus";
  * Import your Room files
  */
 import { CrewRoom } from "./rooms/CrewRoom";
+import { getHighScores, generateRandomHighScore, addHighScore } from "./db/highscores";
 
 export default config({
 
@@ -35,6 +36,29 @@ export default config({
             } catch (err) {
                 console.error("failed to get available rooms", err);
                 res.status(500).json({ error: "failed_to_fetch_rooms" });
+            }
+        });
+
+        // Return saved high scores ordered by difficulty
+        app.get("/highscores", async (_req, res) => {
+            try {
+                const scores = await getHighScores();
+                res.json(scores);
+            } catch (err) {
+                console.error("failed to get highscores", err);
+                res.status(500).json({ error: "failed_to_fetch_highscores" });
+            }
+        });
+
+        // Create a random high score entry (for testing)
+        app.post("/highscores/random", async (_req, res) => {
+            try {
+                const record = generateRandomHighScore();
+                await addHighScore(record);
+                res.json(record);
+            } catch (err) {
+                console.error("failed to generate highscore", err);
+                res.status(500).json({ error: "failed_to_create_highscore" });
             }
         });
 

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -1,0 +1,24 @@
+import 'dotenv/config';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { parse } from 'pg-connection-string';
+
+// Parse connection details from DATABASE_URL. This avoids issues where
+// the connection string isn't parsed correctly by `pg` when undefined or
+// malformed.
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error('DATABASE_URL env variable not set');
+}
+
+const cfg = parse(connectionString);
+
+const pool = new Pool({
+  host: cfg.host,
+  port: cfg.port ? parseInt(cfg.port, 10) : undefined,
+  user: cfg.user,
+  password: cfg.password ?? '',
+  database: cfg.database,
+});
+
+export const db = drizzle(pool);

--- a/src/db/highscores.ts
+++ b/src/db/highscores.ts
@@ -1,0 +1,72 @@
+import { desc } from 'drizzle-orm';
+import { db } from './connection';
+import { highScoresTable, NewHighScore, HighScore } from './schema';
+import { CrewGameState } from '../rooms/schema/CrewRoomState';
+import { ExpansionTask } from '../rooms/schema/CrewTypes';
+
+/**
+ * Insert a high score record into the database.
+ */
+export async function addHighScore(record: NewHighScore): Promise<void> {
+  await db.insert(highScoresTable).values(record);
+}
+
+/**
+ * Insert a high score entry based on the finished game state.
+ */
+export async function addHighScoreFromState(state: CrewGameState): Promise<void> {
+  const players = state.playerOrder.map(id => state.players.get(id)?.displayName || '');
+
+  const tasks = state.allTasks.map(t => {
+    const task = t as ExpansionTask;
+    return {
+      displayName: task.displayName,
+      player: state.players.get(task.player)?.displayName || '',
+    };
+  });
+
+  const difficulty = state.allTasks.reduce((sum, t) => sum + (t as ExpansionTask).difficulty, 0);
+
+  const record: NewHighScore = {
+    createdAt: new Date(),
+    players,
+    undoUsed: state.undoUsed,
+    tasks,
+    difficulty,
+  };
+
+  try {
+    await addHighScore(record);
+  } catch (err) {
+    console.error('failed to insert high score', err);
+  }
+}
+
+export async function getHighScores(): Promise<HighScore[]> {
+  return db.select().from(highScoresTable).orderBy(desc(highScoresTable.difficulty));
+}
+
+/**
+ * Generate a random high score record for testing purposes.
+ */
+export function generateRandomHighScore(): NewHighScore {
+  const names = ['Alpha', 'Bravo', 'Charlie', 'Delta', 'Echo'];
+  const shuffled = names.sort(() => Math.random() - 0.5);
+  const players = shuffled.slice(0, Math.floor(Math.random() * 3) + 2);
+
+  const taskCount = Math.floor(Math.random() * 3) + 1;
+  const tasks = Array.from({ length: taskCount }, (_, i) => ({
+    displayName: `Task ${i + 1}`,
+    player: players[i % players.length],
+  }));
+
+  const difficulty = Math.floor(Math.random() * 10) + 1;
+
+  return {
+    createdAt: new Date(),
+    players,
+    undoUsed: Math.random() < 0.5,
+    tasks,
+    difficulty,
+  };
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,10 +1,26 @@
-// TODO: Create table for highscores in here - see example below.
+import {
+  pgTable,
+  serial,
+  timestamp,
+  jsonb,
+  boolean,
+  integer,
+} from "drizzle-orm/pg-core";
+import { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
-// import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
+/**
+ * Table storing completed expansion games that resulted in a high score.
+ */
+export const highScoresTable = pgTable("high_scores", {
+  id: serial("id").primaryKey(),
+  createdAt: timestamp("created_at", { withTimezone: false, mode: "date" })
+    .notNull()
+    .defaultNow(),
+  players: jsonb("players").notNull().$type<string[]>(),
+  undoUsed: boolean("undo_used").notNull(),
+  tasks: jsonb("tasks").notNull().$type<{ displayName: string; player: string }[]>(),
+  difficulty: integer("difficulty").notNull(),
+});
 
-// export const usersTable = pgTable("users", {
-//   id: integer().primaryKey().generatedAlwaysAsIdentity(),
-//   name: varchar({ length: 255 }).notNull(),
-//   age: integer().notNull(),
-//   email: varchar({ length: 255 }).notNull().unique(),
-// });
+export type HighScore = InferSelectModel<typeof highScoresTable>;
+export type NewHighScore = InferInsertModel<typeof highScoresTable>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,7 @@
  */
 
 import 'dotenv/config';
-import { drizzle } from 'drizzle-orm/node-postgres';
-const db = drizzle(process.env.DATABASE_URL!);
+import './db/connection';
 
 import { listen } from "@colyseus/tools";
 

--- a/src/rooms/schema/CrewRoomState.ts
+++ b/src/rooms/schema/CrewRoomState.ts
@@ -25,5 +25,8 @@ export class CrewGameState extends Schema {
   @type("boolean") gameSucceeded: boolean = false;
   @type("string") currentGameStage: GameStage = GameStage.NotStarted;
 
+  // Track if any undo was used during the game
+  @type("boolean") undoUsed: boolean = false;
+
   @type({ map: PlayerHistory }) historyPlayerStats = new MapSchema<PlayerHistory>();
 }


### PR DESCRIPTION
## Summary
- parse `DATABASE_URL` before creating pg pool
- expose helper to add generic high scores
- generate random high scores for testing
- offer `/highscores/random` endpoint to create a test record

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869903a4e68832cbe5c4d6b7f9cdc3b