### PR TITLE
Fix highscore DB connection and add test endpoint

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -7,7 +7,7 @@ import { matchMaker } from "colyseus";
  * Import your Room files
  */
 import { CrewRoom } from "./rooms/CrewRoom";
-import { getHighScores } from "./db/highscores";
+import { getHighScores, addRandomHighScore } from "./db/highscores";
 
 export default config({
 
@@ -47,6 +47,17 @@ export default config({
             } catch (err) {
                 console.error("failed to get highscores", err);
                 res.status(500).json({ error: "failed_to_fetch_highscores" });
+            }
+        });
+
+        // Convenience endpoint to create a random high score for testing
+        app.post("/highscores/random", async (_req, res) => {
+            try {
+                const score = await addRandomHighScore();
+                res.json(score);
+            } catch (err) {
+                console.error("failed to create random highscore", err);
+                res.status(500).json({ error: "failed_to_create_highscore" });
             }
         });
 

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -2,6 +2,16 @@ import 'dotenv/config';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL! });
+let dbInstance: ReturnType<typeof drizzle> | null = null;
 
-export const db = drizzle(pool);
+const databaseUrl = process.env.DATABASE_URL;
+if (typeof databaseUrl === 'string' && databaseUrl.length > 0) {
+  const pool = new Pool({ connectionString: databaseUrl });
+  dbInstance = drizzle(pool);
+} else {
+  console.warn(
+    'DATABASE_URL environment variable not set. High score features are disabled.'
+  );
+}
+
+export const db = dbInstance;

--- a/src/db/highscores.ts
+++ b/src/db/highscores.ts
@@ -4,10 +4,16 @@ import { highScoresTable, NewHighScore, HighScore } from './schema';
 import { CrewGameState } from '../rooms/schema/CrewRoomState';
 import { ExpansionTask } from '../rooms/schema/CrewTypes';
 
+const dbAvailable = db !== null && db !== undefined;
+
 /**
  * Insert a high score entry based on the finished game state.
  */
 export async function addHighScoreFromState(state: CrewGameState): Promise<void> {
+  if (!dbAvailable) {
+    console.warn('Database not configured. High score will not be stored.');
+    return;
+  }
   const players = state.playerOrder.map(id => state.players.get(id)?.displayName || '');
 
   const tasks = state.allTasks.map(t => {
@@ -29,12 +35,49 @@ export async function addHighScoreFromState(state: CrewGameState): Promise<void>
   };
 
   try {
-    await db.insert(highScoresTable).values(record);
+    await db!.insert(highScoresTable).values(record);
   } catch (err) {
     console.error('failed to insert high score', err);
   }
 }
 
 export async function getHighScores(): Promise<HighScore[]> {
-  return db.select().from(highScoresTable).orderBy(desc(highScoresTable.difficulty));
+  if (!dbAvailable) return [];
+  return db!.select().from(highScoresTable).orderBy(desc(highScoresTable.difficulty));
+}
+
+/**
+ * Insert a randomly generated high score record.
+ * Useful for testing the high score API.
+ */
+export async function addRandomHighScore(): Promise<HighScore | null> {
+  if (!dbAvailable) {
+    console.warn('Database not configured. Random high score not stored.');
+    return null;
+  }
+
+  // generate between 3 and 5 players
+  const playerCount = Math.floor(Math.random() * 3) + 3;
+  const players: string[] = [];
+  for (let i = 0; i < playerCount; i++) {
+    players.push(`Player${i + 1}`);
+  }
+
+  const taskCount = Math.floor(Math.random() * 4) + 1;
+  const tasks: { displayName: string; player: string }[] = [];
+  for (let i = 0; i < taskCount; i++) {
+    const player = players[Math.floor(Math.random() * players.length)];
+    tasks.push({ displayName: `Task ${i + 1}`, player });
+  }
+
+  const record: NewHighScore = {
+    createdAt: new Date(),
+    players,
+    undoUsed: Math.random() < 0.5,
+    tasks,
+    difficulty: tasks.length,
+  };
+
+  const [result] = await db!.insert(highScoresTable).values(record).returning();
+  return result;
 }


### PR DESCRIPTION
## Summary
- handle missing database credentials gracefully and warn user
- guard high score helpers when DB connection is unavailable
- add helper to create random high scores
- expose `/highscores/random` API endpoint to generate a random high score

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a0dfcf2c832c9eca86c87fc845c2