### PR TITLE
Standardize cross-game room message names

### DIFF
--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -1,0 +1,23 @@
+export const RoomMessage = {
+  KICK_PLAYER: "kick_player",
+  KICKED: "kicked",
+  ROOM_CLOSED: "room_closed",
+  SEND_EMOJI: "send_emoji",
+  PLAYER_EMOJI: "player_emoji",
+  RESTART_GAME: "restart_game",
+} as const;
+
+export type RoomMessageValue = (typeof RoomMessage)[keyof typeof RoomMessage];
+
+export interface RoomClosedPayload {
+  reason: "inactivity_timeout";
+}
+
+export type KickPlayerPayload = string;
+
+export interface PlayerEmojiPayload {
+  from: string;
+  name: string;
+  emoji: string;
+  sentAt: number;
+}


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for common room/lobby message names so different games can share the same client-side lobby UI.
- Avoid duplicated raw string literals for room-level messages and reduce client wiring when adding new game rooms.
- Keep existing CrewRoom behaviour intact while making names reusable across future rooms.
- Add lightweight payload types so message semantics are clear for server and client consumers.

### Description
- Add `src/shared/messages.ts` which exports `RoomMessage` string constants and TypeScript payload types for the standard room messages.
- Replace raw message strings in `src/rooms/CrewRoom.ts` with the shared constants such as `RoomMessage.ROOM_CLOSED`, `RoomMessage.KICK_PLAYER`, `RoomMessage.KICKED`, `RoomMessage.SEND_EMOJI`, `RoomMessage.PLAYER_EMOJI`, and `RoomMessage.RESTART_GAME`.
- Preserve existing semantics and permission checks (e.g. host-only `kick_player` and `restart_game`, pre-game restriction for kicking, broadcasting `player_emoji` to all including sender).
- Add `PlayerEmojiPayload`, `RoomClosedPayload`, and `KickPlayerPayload` types to document payload shapes for consumers.

### Testing
- No automated tests were run against these changes.
- Code changes were compiled by inspection and file updates committed, but no CI build or test suite execution was invoked.
- Basic repo grep was used to verify the new constants are referenced in `CrewRoom` and the new file was added.
- Manual runtime verification is recommended (start server and exercise kick/emoji/restart/room-close flows) as a follow-up automated test step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69617d769fc4832caced957cd6819604)